### PR TITLE
ID Numbers in Front of File Names to Stop Triple Duplicates

### DIFF
--- a/meesh_autotest.py
+++ b/meesh_autotest.py
@@ -27,10 +27,9 @@ for x in range(int(sys.argv[1]), int(sys.argv[2])):
     page = requests.get('https://cmsc420.cs.umd.edu/meeshquest/part2/input/' + str(x), verify=False)
     tree = html.fromstring(page.text)
     filename = (tree.xpath('/html/body/div[2]/div/h4[1]/text()')[0].split("Uploaded As: ")[1])
-    input_filename = "input/" + filename
-    #check if input already exists
-    if (os.path.isfile(input_filename)):
-	   input_filename += "_dup"
+
+    input_filename = "input/" + str(x) + "_" + filename
+
     #print filename
     input = tree.xpath('//div[@class="container theme-showcase"]/div[@class="jumbotron"]/pre/text()')[0]
     #print input[0]
@@ -38,9 +37,7 @@ for x in range(int(sys.argv[1]), int(sys.argv[2])):
     f.write(input)
     f.close()
 
-    output_filename = "output/" + filename
-    if (os.path.isfile(output_filename)):
-	   output_filename += "_dup"
+    output_filename = "output/" + str(x) + "_" + filename
 
     output = tree.xpath('/html/body/div[2]/div/textarea/text()')[0]
     #print output


### PR DESCRIPTION
Hey Ashton, it's Andrew.

When the script tries to rename duplicates, only the first and last duplicate survive the journey into your local directory. Say we have three (or more) files all named `foo.xml` which are scraped by the script. The first will accordingly be named `foo.xml`, the second will be named `foo_dup.xml`, and the third will overwrite `foo_dup.xml`.

This can be fixed by changing
`if (os.path.isfile(input_filename)):`
to
`while (os.path.isfile(input_filename)):`.

The fix I've chosen is instead to add the ID number in front of the file name. Therefore, all tests will be guaranteed to have a unique name and will be easier to find (in my opinion) in case of a failure.
